### PR TITLE
small bug fixes and tests

### DIFF
--- a/contracts/Multisig.vy
+++ b/contracts/Multisig.vy
@@ -99,7 +99,6 @@ def executeTransaction(txIndex: uint256) -> Bytes[256]:
     assert txIndex < len(self.transactions), "Does Not Exist"
     assert self.transactions[txIndex].executed == False, "Transaction Already Executed"
     assert self.transactions[txIndex].numConfirmations >= self.numConfirmationsRequired, "Insufficent Confirmations"
-    assert self.transactions[txIndex].val <= self.balance, "Insufficient multisig balance"
     self.transactions[txIndex].executed = True
     success: bool = False
     response: Bytes[256] = b""

--- a/contracts/Multisig.vy
+++ b/contracts/Multisig.vy
@@ -1,0 +1,153 @@
+# @version ^0.3.7
+
+"""
+@title Multisig implementation in Vyper
+@license MIT
+@author crypdough.eth, jakubwarmuz.eth
+@notice Multisig contract
+@dev Basic implementation of a multisig
+"""
+#######################################################################################  
+# CONFIGURATION
+####################################################################################### 
+event Deposit:
+    sender: indexed(address)
+    amount: uint256
+    bal: uint256
+event SubmitTransaction:
+    owner: indexed(address)
+    txIndex: indexed(uint256)
+    to: indexed(address)
+    value: uint256
+    data: Bytes[256]
+event ConfirmTransaction:
+    owner: indexed(address)
+    txIndex: indexed(uint256)
+event RevokeConfirmation:
+    owner: indexed(address)
+    txIndex: indexed(uint256)
+event ExecuteTransaction:
+    owner: indexed(address)
+    txIndex: indexed(uint256)
+
+struct Transaction: 
+    to: address
+    val: uint256
+    data: Bytes[256]
+    executed: bool
+    numConfirmations: uint256
+
+#######################################################################################  
+# STATE VARIABLES
+#######################################################################################  
+owners: DynArray[address, 100]
+isOwner: HashMap[address, bool]
+numConfirmationsRequired: uint256
+
+# Mapping from txIndex to a mapping of [address, bool], denoting the tx confirmation by a given address
+isConfirmed: public(HashMap[uint256, HashMap[address, bool]])
+
+# Dynamic Array with all the submitted transactions
+# Shouldn't we be popping the transactions that have been executed from this array after the tx confirmation?
+# The way it is now, there is a total of 10k txs that can be submitted using this multisig implementation (or is this not correct?)
+transactions: DynArray[Transaction, 10000]
+
+#######################################################################################  
+# INITIALIZATION FUNCTION
+#######################################################################################  
+@external
+def __init__ (_numConfirmationsRequired: uint256, _owners: DynArray[address,100]):
+    assert len(_owners) > 0, "Error: No Owners"
+    assert _numConfirmationsRequired > 0 and _numConfirmationsRequired <= len(_owners)
+    self.numConfirmationsRequired = _numConfirmationsRequired
+    for o in _owners:
+        assert o != empty(address)
+        assert self.isOwner[o] == False, "Owner Not Unique"
+        self.isOwner[o] = True
+        self.owners.append(o)
+
+#######################################################################################  
+# EXTERNAL FUNCTIONS
+####################################################################################### 
+@external
+@payable
+def __default__():
+    log Deposit(msg.sender, msg.value, self.balance)
+
+@external
+def submitTransaction( _to: address, _val: uint256, _data: Bytes[256]):
+    assert self.isOwner[msg.sender] == True, "Not an Owner"
+    txIndex: uint256 = len(self.transactions)
+    self.transactions.append(Transaction({to:_to, val:_val, data: _data, executed: False, numConfirmations: 0}))    
+
+@external 
+def confirmTransaction(txIndex: uint256):
+    assert self.isOwner[msg.sender]==True, "Not an Owner"
+    assert txIndex < len(self.transactions), "Does Not Exist"
+    assert self.transactions[txIndex].executed == False, "Transaction Already Executed"
+    assert self.isConfirmed[txIndex][msg.sender] == False, "Transaction Already Confirmed"
+    # increment the number of tx confirmations
+    self.transactions[txIndex].numConfirmations += 1
+    # take note of the msg sender signing the tx
+    self.isConfirmed[txIndex][msg.sender] = True
+    log ConfirmTransaction(msg.sender, txIndex)
+
+
+@payable
+@external
+def executeTransaction(txIndex: uint256) -> Bytes[256]:
+    assert self.isOwner[msg.sender]==True, "Not an Owner"
+    assert txIndex < len(self.transactions), "Does Not Exist"
+    assert self.transactions[txIndex].executed == False, "Transaction Already Executed"
+    assert self.transactions[txIndex].numConfirmations >= self.numConfirmationsRequired, "Insufficent Confirmations"
+    assert self.transactions[txIndex].val <= self.balance, "Insufficient multisig balance"
+    success: bool = False
+    response: Bytes[256] = b""
+    success, response = raw_call(
+        self.transactions[txIndex].to, 
+        self.transactions[txIndex].data,
+        max_outsize=256, # what's that?
+        value = self.transactions[txIndex].val,
+        revert_on_failure = False # what is this and why we need it to be False?
+    )
+    assert success
+    # label the tx as executed after success is confirmed
+    self.transactions[txIndex].executed = True
+    # shouldn't we pop out the tx from self.transactions if it has been executed correctly?
+    return response
+
+
+@nonpayable
+@external
+def revokeConfirmation(_txIndex: uint256):
+    assert _txIndex < len(self.transactions), "Does Not Exist"
+    assert self.transactions[_txIndex].executed == False, "Transaction Already Executed"
+    # added to the original: the non-owner can't revoke
+    assert self.isOwner[msg.sender]==True, "Not an Owner"
+    # decrement the number of tx confirmations
+    # only if the msg sender has already signed the tx before
+    assert self.isConfirmed[_txIndex][msg.sender] == True, "The owner has to sign first before being able to revoke the signature"
+    self.transactions[_txIndex].numConfirmations -= 1
+    self.isConfirmed[_txIndex][msg.sender] = False
+    log RevokeConfirmation(msg.sender, _txIndex)
+
+@view
+@external
+def getOwners() -> DynArray[address, 100]:
+    return self.owners
+
+@view
+@external 
+def getTransactionCount() -> uint256:
+    return len(self.transactions)
+
+@view
+@external 
+def getTransaction(_txIndex: uint256) -> (address, uint256, Bytes[256], bool, uint256):
+    return(
+        self.transactions[_txIndex].to,
+        self.transactions[_txIndex].val,
+        self.transactions[_txIndex].data,
+        self.transactions[_txIndex].executed,
+        self.transactions[_txIndex].numConfirmations
+    )

--- a/scripts/deploy.py
+++ b/scripts/deploy.py
@@ -1,0 +1,9 @@
+#!/usr/bin/python3
+
+from brownie import Multisig, accounts, network
+
+N = 2
+
+
+def main():
+    return Multisig.deploy(N, [accounts[0], accounts[1]], {"from": accounts[0]})

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,17 @@
+#!/usr/bin/python3
+
+import pytest
+
+
+@pytest.fixture(scope="function", autouse=True)
+def isolate(fn_isolation):
+    # perform a chain rewind after completing each test, to ensure proper isolation
+    # https://eth-brownie.readthedocs.io/en/v1.10.3/tests-pytest-intro.html#isolation-fixtures
+    pass
+
+
+@pytest.fixture(scope="module")
+def multisig(Multisig, accounts):
+    N = 2
+    owners = [accounts[0], accounts[1]]
+    return Multisig.deploy(N, owners, {"from": accounts[0]})

--- a/tests/test_acc_balances.py
+++ b/tests/test_acc_balances.py
@@ -1,0 +1,46 @@
+#!/usr/bin/python3
+
+import pytest
+from brownie.convert import to_bytes
+
+
+def test_multisig_sends(multisig, accounts):
+    alice = accounts[0]
+    bob = accounts[1]
+    eve = accounts[2]
+    # fund the multisig
+    init_alice_balance = alice.balance()
+    init_eve_balance = eve.balance()
+    init_multisig_balance = multisig.balance()
+    amount_to_fund = 10**20
+    alice.transfer(to=multisig, amount=amount_to_fund)
+    mid_alice_balance = alice.balance()
+    assert (
+        mid_alice_balance < init_alice_balance
+    ), "Multisig funder's balance should decrease"
+    mid_multisig_balance = multisig.balance()
+    assert (
+        mid_multisig_balance > init_multisig_balance
+    ), "Multisig's balance should increase after the funding tx"
+    _to = eve
+    val = 10**19
+    _bytes = to_bytes("0x01")
+    multisig.submitTransaction(_to, val, _bytes, {"from": alice})
+    assert (
+        mid_alice_balance - alice.balance() < val
+    ), "Submitting transaction costs Alice paymentAmount"
+    # confirm the tx
+    multisig.confirmTransaction(0, {"from": alice})
+    multisig.confirmTransaction(0, {"from": bob})
+    final_alice_balance = alice.balance()
+    # we know the above works from other tests so skipping the asserts here
+    response = multisig.executeTransaction(0)
+    _tx = multisig.getTransaction(0)
+    assert _tx[3] == True, "Tx should have been executed"
+    assert (
+        alice.balance() == final_alice_balance
+    ), "Owner balance decreases after multisig tx execution"
+    assert (
+        init_eve_balance < eve.balance()
+    ), "Destination address should have more balance after tx execution"
+    assert mid_multisig_balance > multisig.balance(), "Multisig balance should decrease"

--- a/tests/test_execute_tx.py
+++ b/tests/test_execute_tx.py
@@ -1,0 +1,72 @@
+#!/usr/bin/python3
+
+import pytest
+from brownie.convert import to_bytes
+from brownie import reverts
+
+
+def test_signed_executes(multisig, accounts):
+    # fund the multisig
+    amount_to_fund = 10**20
+    accounts[4].transfer(to=multisig, amount=amount_to_fund)
+    _to = accounts[2]
+    val = 10**19
+    _bytes = to_bytes("0x01")
+    multisig.submitTransaction(_to, val, _bytes, {"from": accounts[0]})
+    # confirm the tx
+    multisig.confirmTransaction(0, {"from": accounts[0]})
+    multisig.confirmTransaction(0, {"from": accounts[1]})
+    # we know the above works from other tests so skipping the asserts here
+    response = multisig.executeTransaction(0)
+    _tx = multisig.getTransaction(0)
+    assert _tx[3] == True, "Tx should have been executed"
+
+
+def test_insufficient_balance(multisig, accounts):
+    # fund the multisig
+    amount_to_fund = 10**18
+    accounts[4].transfer(to=multisig, amount=amount_to_fund)
+    _to = accounts[2]
+    val = 10**19
+    assert multisig.balance() < val
+    _bytes = to_bytes("0x01")
+    multisig.submitTransaction(_to, val, _bytes, {"from": accounts[0]})
+    # confirm the tx
+    multisig.confirmTransaction(0, {"from": accounts[0]})
+    multisig.confirmTransaction(0, {"from": accounts[1]})
+    # we know the above works from other tests so skipping the asserts here
+    with reverts():
+        response = multisig.executeTransaction(0)
+
+
+def test_not_enough_signatures(multisig, accounts):
+    # fund the multisig
+    amount_to_fund = 10**20
+    accounts[4].transfer(to=multisig, amount=amount_to_fund)
+    _to = accounts[2]
+    val = 10**19
+    _bytes = to_bytes("0x01")
+    multisig.submitTransaction(_to, val, _bytes, {"from": accounts[0]})
+    # confirm the tx
+    multisig.confirmTransaction(0, {"from": accounts[0]})
+    # we know the above works from other tests so skipping the asserts here
+    with reverts():
+        response = multisig.executeTransaction(0)
+
+
+def test_not_enough_signatures_after_revoke(multisig, accounts):
+    # fund the multisig
+    amount_to_fund = 10**20
+    accounts[4].transfer(to=multisig, amount=amount_to_fund)
+    _to = accounts[2]
+    val = 10**19
+    _bytes = to_bytes("0x01")
+    multisig.submitTransaction(_to, val, _bytes, {"from": accounts[0]})
+    # confirm the tx
+    multisig.confirmTransaction(0, {"from": accounts[0]})
+    multisig.confirmTransaction(0, {"from": accounts[1]})
+    # we know the above works from other tests so skipping the asserts here
+    # revoke the confirmation
+    multisig.revokeConfirmation(0, {"from": accounts[0]})
+    with reverts():
+        response = multisig.executeTransaction(0)

--- a/tests/test_sign_tx.py
+++ b/tests/test_sign_tx.py
@@ -1,0 +1,61 @@
+#!/usr/bin/python3
+
+import pytest
+from brownie.convert import to_bytes
+from brownie import reverts
+
+
+def test_owner_can_sign(multisig, accounts):
+    _to = accounts[2]
+    val = 10**19
+    _bytes = to_bytes("0x01")
+    multisig.submitTransaction(_to, val, _bytes, {"from": accounts[0]})
+    # confirm the tx
+    multisig.confirmTransaction(0, {"from": accounts[0]})
+    _tx = multisig.getTransaction(0)
+    assert _tx[3] == False, "Tx shouldn't have been executed"
+    assert _tx[4] == 1, "Tx should have been signed by 1 owner"
+    multisig.confirmTransaction(0, {"from": accounts[1]})
+    _tx = multisig.getTransaction(0)
+    assert _tx[3] == False, "Tx shouldn't have been executed"
+    assert _tx[4] == 2, "Tx should have been signed by 2 owners"
+
+
+def test_non_owner_cant_sign(multisig, accounts):
+    _to = accounts[2]
+    val = 10**19
+    _bytes = to_bytes("0x01")
+    multisig.submitTransaction(_to, val, _bytes, {"from": accounts[0]})
+    # try signing by non-owner
+    with reverts():
+        multisig.confirmTransaction(0, {"from": accounts[3]})
+
+
+def test_owner_can_revoke(multisig, accounts):
+    _to = accounts[2]
+    val = 10**19
+    _bytes = to_bytes("0x01")
+    multisig.submitTransaction(_to, val, _bytes, {"from": accounts[0]})
+    # confirm the tx
+    multisig.confirmTransaction(0, {"from": accounts[0]})
+    _tx = multisig.getTransaction(0)
+    assert _tx[3] == False, "Tx shouldn't have been executed"
+    assert _tx[4] == 1, "Tx should have been signed by 1 owner"
+    multisig.revokeConfirmation(0, {"from": accounts[0]})
+    _tx = multisig.getTransaction(0)
+    assert _tx[3] == False, "Tx shouldn't have been executed"
+    assert _tx[4] == 0, "Tx confirmation should have been revoked"
+
+
+def test_non_owner_cant_revoke(multisig, accounts):
+    _to = accounts[2]
+    val = 10**19
+    _bytes = to_bytes("0x01")
+    multisig.submitTransaction(_to, val, _bytes, {"from": accounts[0]})
+    # confirm the tx
+    multisig.confirmTransaction(0, {"from": accounts[0]})
+    _tx = multisig.getTransaction(0)
+    assert _tx[3] == False, "Tx shouldn't have been executed"
+    assert _tx[4] == 1, "Tx should have been signed by 1 owner"
+    with reverts():
+        multisig.revokeConfirmation(0, {"from": accounts[3]})

--- a/tests/test_submit_tx.py
+++ b/tests/test_submit_tx.py
@@ -1,0 +1,31 @@
+#!/usr/bin/python3
+
+import pytest
+from brownie.convert import to_bytes
+from brownie import reverts
+
+
+def test_tx_count_incremented(multisig, accounts):
+    init_tx_num = multisig.getTransactionCount()
+    _to = accounts[2]
+    val = 10**19
+    _bytes = b"\x01"
+    multisig.submitTransaction(_to, val, _bytes, {"from": accounts[0]})
+    assert multisig.getTransactionCount() > init_tx_num
+
+
+def test_only_submitted(multisig, accounts):
+    _to = accounts[2]
+    val = 10**19
+    _bytes = to_bytes("0x01")
+    multisig.submitTransaction(_to, val, _bytes, {"from": accounts[0]})
+    _tx = multisig.getTransaction(0)
+    assert _tx[0] == _to, "Destination address not matching"
+    assert _tx[1] == val, "Value not matching"
+    # not sure if below is actually the desired behavior.
+    # The _tx[2] object is of type <class 'brownie.convert.datatypes.HexString'>
+    # which is different than the bytes type passed
+    # but maybe it's how the EVM works under the hood
+    assert to_bytes(_tx[2]) == _bytes, "Tx data not matching"
+    assert _tx[3] == False, "Tx shouldn't have been executed"
+    assert _tx[4] == 0, "Tx should not have been signed"


### PR DESCRIPTION
- added comments to Multisig.vy
- changed _data: Bytes[512] to Bytes[256] in the submitTransaction() function
- added a check for sufficient multisig balance in the executeTransaction() function
- moved `self.transactions[txIndex].executed = True` in executeTransaction() function to after the success is asserted
- added a check for one of the owners revoking the confirmation in revokeConfirmation() function
- added tests